### PR TITLE
Add minimal note to docu section and fix code indentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,17 +55,17 @@ will validate the source of the package by executing regression tests.
 For developers
 --------------
 
-To perform pylint static checking from the top level directory of the project, use
+To perform pylint static checking from the top level directory of the project, use::
 
-pylint3 --rcfile utils/srccheck/pylint/pylintrc-3.ini src/*
+  pylint --rcfile utils/srccheck/pylint/pylintrc-3.ini src/*
 
 
 Documentation
 =============
 
-Consult following resources for documentation:
+Consult following resources for the (currently very limited) documentation:
 
-* ToDo
+* automatically generated Argparse help page of the corresponding script
 
 
 License


### PR DESCRIPTION
Fix indentation of 'For developers' section and add a minimal note to documentation section.